### PR TITLE
pass sort=True to df.append() to avoid warning

### DIFF
--- a/implementations/Code_Changes-Git.ipynb
+++ b/implementations/Code_Changes-Git.ipynb
@@ -130,7 +130,7 @@
     "                commit = json.loads(line)\n",
     "                commits.append(self._summary(repo=commit['origin'],\n",
     "                                             cdata=commit['data']))\n",
-    "        self.df = self.df.append(commits)\n",
+    "        self.df = self.df.append(commits, sort=True)\n",
     "        self.df['author_date'] = pd.to_datetime(self.df['author_date'], utc=True)\n",
     "        self.df['commit_date'] = pd.to_datetime(self.df['commit_date'], utc=True)\n",
     "        \n",


### PR DESCRIPTION
While running the script, I noticed that the sort warning popped up for the append() method. [Link to pandas documentation mentioning the change](http://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.append.html?highlight=append#pandas.DataFrame.append). 
![screenshot from 2019-02-16 21-21-36](https://user-images.githubusercontent.com/31214064/52902118-535f0300-3232-11e9-9e86-6a7c727989d3.png)
