### PR TITLE
Fix non existent Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ The metrics dealt with in this focus group are organized in focus areas:
   * [Code Development](./focus_areas/code_development.md)
   * [Community Growth](./focus_areas/community_growth.md)
   * [Issue Resolution](./focus_areas/issue_resolution.md)
-* [Risk](./focus_areas/risk/risk.md)
-* [Value](./focus_areas/value/value.md)
+* [Risk](./focus_areas/risk.md)
+* [Value](./focus_areas/value.md)
 
 ## Usage
 


### PR DESCRIPTION
Links to risk and value metrics were pointed at nonexistent folders. This also fixes #89 most probably. 