### PR TITLE
fixed the broken link for LICENSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,6 @@ as a pull request for updating the CHAOSS metriccs with
 
 ## License
 
-The documents in this repositories are released undet the MIT License. See [LICENSE.md](LICENSE.md) for details.
+The documents in this repositories are released undet the MIT License. See [LICENSE](LICENSE) for details.
 
 Copyright © 2018-2019 CHAOSS Project


### PR DESCRIPTION
I changed the path and name of the LICENSE in the README.
Solves #105 