### PR TITLE
[DCO-plugin]add DCO browser plugin instructions to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ To enable this plugin:
 
 - Then, whenever you perform a commit on github, the line `Signed-off-by: Your Name <Youremail>` will automatically appear in the commit description while making changes to a file as shown in the example below. A commit message can be added to the lines above the auto-generated sign-off. 
 
-![image](https://user-images.githubusercontent.com/31214064/55422689-dac1c500-5599-11e9-8bf3-2ec08f2cd046.png)    
+![image2](https://user-images.githubusercontent.com/31214064/55423206-127d3c80-559b-11e9-9a5e-6300105b8858.png)
 
 - Once you perform the commit and send a pull request, the commit will be verified and approved by the DCO bot. 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,15 +63,15 @@ To enable this plugin:
 - Once you add the extension, right click on the extension in the toolbar of your browser and select `Options`. 
 - A dialog box will open up as shown below. Fill in your github name (not the handle) and email-id. 
 
- ![](https://user-images.githubusercontent.com/31214064/55411911-194c8500-5584-11e9-8b56-c8f94b6fa213.png)
+ ![Screenshot of settings for DCO GitHub UI](https://user-images.githubusercontent.com/31214064/55411911-194c8500-5584-11e9-8b56-c8f94b6fa213.png)
 
 - Then, whenever you perform a commit on github, the line `Signed-off-by: Your Name <Youremail>` will automatically appear in the commit description while making changes to a file as shown in the example below. A commit message can be added to the lines above the auto-generated sign-off. 
 
-![image2](https://user-images.githubusercontent.com/31214064/55423206-127d3c80-559b-11e9-9a5e-6300105b8858.png)
+![Screenshot of GitHub UI with auto-generated sign-off in commit message](https://user-images.githubusercontent.com/31214064/55423206-127d3c80-559b-11e9-9a5e-6300105b8858.png)
 
 - Once you perform the commit and send a pull request, the commit will be verified and approved by the DCO bot. 
 
- ![Image](https://user-images.githubusercontent.com/31214064/55415829-5f591700-558b-11e9-93ae-07b0ed432a53.png)
+ ![Screenshot of successful DCO check](https://user-images.githubusercontent.com/31214064/55415829-5f591700-558b-11e9-93ae-07b0ed432a53.png)
 
 
 ## More Information

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,8 @@ in a single line, into the commit comment field. This can be automated by using 
 - Then, whenever you perform a commit on github, the line `Signed-off-by: Your Name <Youremail>` will automatically appear in the commit description while making changes to a file as shown in the example below. A commit message can be added to the lines above the auto-generated sign-off. 
 <p align="center">
   <img src="https://user-images.githubusercontent.com/31214064/55412140-7ea07600-5584-11e9-8200-52cf068253ee.png" width="500">
-</p>                                                                                                                         
+</p>     
+
 - Once you perform the commit and send a pull request, the commit will be verified and approved by the DCO bot. 
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,26 @@ Signed-off-by: Your Name <YourName@example.org>
 in a single line, into the commit comment field. This can be automated by using a browser plugin like
 [DCO GitHub UI](https://github.com/scottrigby/dco-gh-ui).
 
+#### Steps to use the DCO browser plugin
+- Go to the plugin page on [chrome web store](https://chrome.google.com/webstore/detail/dco-github-ui/onhgmjhnaeipfgacbglaphlmllkpoijo).
+- You could also go to the [firefox page](https://addons.mozilla.org/en-US/firefox/addon/scott-rigby/)
+- Once you add the extension, right click on the extension in the toolbar of your browser and select `Options`. 
+- A dialog box will open up as shown below. Fill in your github name (not the handle) and email-id. 
+<p align="center">
+  <img src="https://user-images.githubusercontent.com/31214064/55411911-194c8500-5584-11e9-8b56-c8f94b6fa213.png" width="300">
+</p>
+
+- Then, whenever you perform a commit on github, the line `Signed-off-by: Your Name <Youremail>` will automatically appear in the commit description while making making changes to that file as shown in the example below.
+<p align="center">
+  <img src="https://user-images.githubusercontent.com/31214064/55412140-7ea07600-5584-11e9-8200-52cf068253ee.png" width="500">
+</p>                                                                                                                         
+- Once you perform the commit and send a pull request, the commit will be verified and approved by the DCO bot. 
+
+
+<p align="center">
+  <img src="https://user-images.githubusercontent.com/31214064/55415829-5f591700-558b-11e9-93ae-07b0ed432a53.png" width="300">
+</p>
+
 ## More Information
 For further information on how to collaborate in CHAOSS, please see the CHAOSS [CONTRIBUTING.md](https://github.com/chaoss/governance/blob/master/CONTRIBUTING.md).
 We are committed to providing an inclusive and welcoming environment. Please see our [Code of Conduct.](https://github.com/chaoss/governance/blob/master/code-of-conduct.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,15 +55,15 @@ in a single line, into the commit comment field. This can be automated by using 
 [DCO GitHub UI](https://github.com/scottrigby/dco-gh-ui).
 
 #### Steps to use the DCO browser plugin
-- Go to the plugin page on [chrome web store](https://chrome.google.com/webstore/detail/dco-github-ui/onhgmjhnaeipfgacbglaphlmllkpoijo).
-- You could also go to the [firefox page](https://addons.mozilla.org/en-US/firefox/addon/scott-rigby/)
+- Go to the plugin page on the [chrome web store](https://chrome.google.com/webstore/detail/dco-github-ui/onhgmjhnaeipfgacbglaphlmllkpoijo).
+- Alternatively, you could go to the [firefox addon page](https://addons.mozilla.org/en-US/firefox/addon/scott-rigby/) to add the extension to your browser.
 - Once you add the extension, right click on the extension in the toolbar of your browser and select `Options`. 
 - A dialog box will open up as shown below. Fill in your github name (not the handle) and email-id. 
 <p align="center">
   <img src="https://user-images.githubusercontent.com/31214064/55411911-194c8500-5584-11e9-8b56-c8f94b6fa213.png" width="300">
 </p>
 
-- Then, whenever you perform a commit on github, the line `Signed-off-by: Your Name <Youremail>` will automatically appear in the commit description while making making changes to that file as shown in the example below.
+- Then, whenever you perform a commit on github, the line `Signed-off-by: Your Name <Youremail>` will automatically appear in the commit description while making changes to a file as shown in the example below.
 <p align="center">
   <img src="https://user-images.githubusercontent.com/31214064/55412140-7ea07600-5584-11e9-8200-52cf068253ee.png" width="500">
 </p>                                                                                                                         

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,9 @@ in a single line, into the commit comment field. This can be automated by using 
 [DCO GitHub UI](https://github.com/scottrigby/dco-gh-ui).
 
 #### Steps to use the DCO browser plugin
+The  [DCO browser plugin](https://github.com/scottrigby/dco-gh-ui) is a handy tool to automatically sign commits created using github. 
+To enable this plugin: 
+
 - Go to the plugin page on the [chrome web store](https://chrome.google.com/webstore/detail/dco-github-ui/onhgmjhnaeipfgacbglaphlmllkpoijo).
 - Alternatively, you could go to the [firefox addon page](https://addons.mozilla.org/en-US/firefox/addon/scott-rigby/) to add the extension to your browser.
 - Once you add the extension, right click on the extension in the toolbar of your browser and select `Options`. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ in a single line, into the commit comment field. This can be automated by using 
   <img src="https://user-images.githubusercontent.com/31214064/55411911-194c8500-5584-11e9-8b56-c8f94b6fa213.png" width="300">
 </p>
 
-- Then, whenever you perform a commit on github, the line `Signed-off-by: Your Name <Youremail>` will automatically appear in the commit description while making changes to a file as shown in the example below.
+- Then, whenever you perform a commit on github, the line `Signed-off-by: Your Name <Youremail>` will automatically appear in the commit description while making changes to a file as shown in the example below. A commit message can be added to the lines above the auto-generated sign-off. 
 <p align="center">
   <img src="https://user-images.githubusercontent.com/31214064/55412140-7ea07600-5584-11e9-8200-52cf068253ee.png" width="500">
 </p>                                                                                                                         

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,21 +62,17 @@ To enable this plugin:
 - Alternatively, you could go to the [firefox addon page](https://addons.mozilla.org/en-US/firefox/addon/scott-rigby/) to add the extension to your browser.
 - Once you add the extension, right click on the extension in the toolbar of your browser and select `Options`. 
 - A dialog box will open up as shown below. Fill in your github name (not the handle) and email-id. 
-<p align="center">
-  <img src="https://user-images.githubusercontent.com/31214064/55411911-194c8500-5584-11e9-8b56-c8f94b6fa213.png" width="300">
-</p>
+
+ ![](https://user-images.githubusercontent.com/31214064/55411911-194c8500-5584-11e9-8b56-c8f94b6fa213.png)
 
 - Then, whenever you perform a commit on github, the line `Signed-off-by: Your Name <Youremail>` will automatically appear in the commit description while making changes to a file as shown in the example below. A commit message can be added to the lines above the auto-generated sign-off. 
-<p align="center">
-  <img src="https://user-images.githubusercontent.com/31214064/55412140-7ea07600-5584-11e9-8200-52cf068253ee.png" width="500">
-</p>     
+
+![image](https://user-images.githubusercontent.com/31214064/55422689-dac1c500-5599-11e9-8bf3-2ec08f2cd046.png)    
 
 - Once you perform the commit and send a pull request, the commit will be verified and approved by the DCO bot. 
 
+ ![Image](https://user-images.githubusercontent.com/31214064/55415829-5f591700-558b-11e9-93ae-07b0ed432a53.png)
 
-<p align="center">
-  <img src="https://user-images.githubusercontent.com/31214064/55415829-5f591700-558b-11e9-93ae-07b0ed432a53.png" width="300">
-</p>
 
 ## More Information
 For further information on how to collaborate in CHAOSS, please see the CHAOSS [CONTRIBUTING.md](https://github.com/chaoss/governance/blob/master/CONTRIBUTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,17 +55,17 @@ in a single line, into the commit comment field. This can be automated by using 
 [DCO GitHub UI](https://github.com/scottrigby/dco-gh-ui).
 
 #### Steps to use the DCO browser plugin
-The  [DCO browser plugin](https://github.com/scottrigby/dco-gh-ui) is a handy tool to automatically sign commits created using github. 
+The  [DCO browser plugin](https://github.com/scottrigby/dco-gh-ui) is a handy tool to automatically sign commits created using GitHub. 
 To enable this plugin: 
 
 - Go to the plugin page on the [chrome web store](https://chrome.google.com/webstore/detail/dco-github-ui/onhgmjhnaeipfgacbglaphlmllkpoijo).
 - Alternatively, you could go to the [firefox addon page](https://addons.mozilla.org/en-US/firefox/addon/scott-rigby/) to add the extension to your browser.
 - Once you add the extension, right click on the extension in the toolbar of your browser and select `Options`. 
-- A dialog box will open up as shown below. Fill in your github name (not the handle) and email-id. 
+- A dialog box will open up as shown below. Fill in your GitHub name (not the handle) and email-id. 
 
  ![Screenshot of settings for DCO GitHub UI](https://user-images.githubusercontent.com/31214064/55411911-194c8500-5584-11e9-8b56-c8f94b6fa213.png)
 
-- Then, whenever you perform a commit on github, the line `Signed-off-by: Your Name <Youremail>` will automatically appear in the commit description while making changes to a file as shown in the example below. A commit message can be added to the lines above the auto-generated sign-off. 
+- Then, whenever you perform a commit on GitHub, the line `Signed-off-by: Your Name <Youremail>` will automatically appear in the commit description while making changes to a file as shown in the example below. A commit message can be added to the lines above the auto-generated sign-off. 
 
 ![Screenshot of GitHub UI with auto-generated sign-off in commit message](https://user-images.githubusercontent.com/31214064/55423206-127d3c80-559b-11e9-9a5e-6300105b8858.png)
 


### PR DESCRIPTION

As discussed in [in this issue](https://github.com/chaoss/wg-diversity-inclusion/issues/170)