### PR TITLE
fix first heading of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# What is this working group about?
+# CHAOSS Growth-Maturity-Decline Working Group
 
 
 [![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)


### PR DESCRIPTION
We pull in the README to WordPress: 
https://chaoss.community/growth-maturity-and-decline/

The website would look better if the first heading was the name of the working group.